### PR TITLE
Update requirements to allow up to Rails 8

### DIFF
--- a/active_shipping.gemspec
+++ b/active_shipping.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
 
   s.add_dependency("measured", ">= 2.0")
-  s.add_dependency("activesupport", ">= 4.2", "< 6.2")
+  s.add_dependency("activesupport", ">= 4.2", "~> 8.0")
   s.add_dependency("active_utils", "~> 3.3.1")
   s.add_dependency("nokogiri", ">= 1.6")
 

--- a/active_shipping.gemspec
+++ b/active_shipping.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
 
   s.add_dependency("measured", ">= 2.0")
-  s.add_dependency("activesupport", ">= 4.2", "~> 8.0")
+  s.add_dependency("activesupport", ">= 4.2")
   s.add_dependency("active_utils", "~> 3.3.1")
   s.add_dependency("nokogiri", ">= 1.6")
 


### PR DESCRIPTION
I don't actually know if the code in this is safe for Rails 8, but this will allow us to upgrade Merchtable. Then we can fix what's broken if necessary.